### PR TITLE
Added support for team owners

### DIFF
--- a/NZ.XrmToolbox.PersonalArtefactManager/AppCode/Events/UserSelectedEventArgs.cs
+++ b/NZ.XrmToolbox.PersonalArtefactManager/AppCode/Events/UserSelectedEventArgs.cs
@@ -2,13 +2,13 @@
 
 namespace NZ.XrmToolbox.PersonalArtefactManager.AppCode.Events
 {
-    internal class UserSelectedEventArgs : EventArgs
+    internal class OwnerSelectedEventArgs : EventArgs
     {
-        public User[] UserSelection { get; private set; }
+        public Owner[] OwnerSelection { get; private set; }
 
-        internal UserSelectedEventArgs(User[] users)
+        internal OwnerSelectedEventArgs(Owner[] owners)
         {
-            UserSelection = users;
+            OwnerSelection = owners;
         }        
     }
 }

--- a/NZ.XrmToolbox.PersonalArtefactManager/AppCode/Form/OwnerListViewBuilder.cs
+++ b/NZ.XrmToolbox.PersonalArtefactManager/AppCode/Form/OwnerListViewBuilder.cs
@@ -1,0 +1,70 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Windows.Forms;
+
+namespace NZ.XrmToolbox.PersonalArtefactManager.AppCode.Form
+{
+    internal class OwnerListViewBuilder : ListViewBuilder
+    {
+        public bool HasCheckboxes { get; set; }
+
+        public OwnerListViewBuilder(bool withCheckboxes = true)
+        {
+            HasCheckboxes = withCheckboxes;
+        }
+
+        public override ListViewItem BuildItem(object artefact)
+        {
+            var owner = (EntityReference)artefact;
+            var cells = new List<string>();
+
+            if (HasCheckboxes) cells.Add(String.Empty);
+
+            cells.AddRange(new string[]
+            {
+                owner.Name,
+                owner.LogicalName,
+            });
+
+            var item = new ListViewItem(cells.ToArray());
+            item.Tag = artefact;
+            return item;
+        }
+
+        public override void BuildColumns(ListView target)
+        {
+            // Clear existing
+            target.Columns.Clear();
+
+            // And rebuild
+
+            var columns = new List<ColumnHeader>();
+
+            if (HasCheckboxes)
+            {
+                columns.Add(new ColumnHeader()
+                {
+                    Text = String.Empty,
+                    Width = 20,
+                });
+            }
+            target.CheckBoxes = HasCheckboxes;
+
+            // Primary Field
+            columns.Add(new ColumnHeader()
+            {
+                Text = "Name",
+                Width = 160,
+            });
+
+            // Primary Field
+            columns.Add(new ColumnHeader()
+            {
+                Text = "LogicalName",
+                Width = 160,
+            });
+                            
+            target.Columns.AddRange(columns.ToArray());
+        }
+    }
+}

--- a/NZ.XrmToolbox.PersonalArtefactManager/AppCode/Form/OwnerListViewBuilder.cs
+++ b/NZ.XrmToolbox.PersonalArtefactManager/AppCode/Form/OwnerListViewBuilder.cs
@@ -15,7 +15,7 @@ namespace NZ.XrmToolbox.PersonalArtefactManager.AppCode.Form
 
         public override ListViewItem BuildItem(object artefact)
         {
-            var owner = (EntityReference)artefact;
+            var owner = (Owner)artefact;
             var cells = new List<string>();
 
             if (HasCheckboxes) cells.Add(String.Empty);

--- a/NZ.XrmToolbox.PersonalArtefactManager/AppCode/IPersonalArtefactManager.cs
+++ b/NZ.XrmToolbox.PersonalArtefactManager/AppCode/IPersonalArtefactManager.cs
@@ -3,13 +3,13 @@
     internal interface IPersonalArtefactManager
     {
 
-        void Duplicate(IPersonalArtefact artefact, User owner);
+        void Duplicate(IPersonalArtefact artefact, Owner owner);
 
-        void Assign(IPersonalArtefact artefact, User newOwner);
+        void Assign(IPersonalArtefact artefact, Owner newOwner);
 
         void Delete(IPersonalArtefact artefact);
 
-        void QueryByUser(User user);
+        void QueryByOwner(Owner owner);
     }
 
     

--- a/NZ.XrmToolbox.PersonalArtefactManager/AppCode/Owner.cs
+++ b/NZ.XrmToolbox.PersonalArtefactManager/AppCode/Owner.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using Microsoft.Xrm.Sdk;
+
+namespace NZ.XrmToolbox.PersonalArtefactManager.AppCode
+{
+    internal class Owner
+    {
+        public EntityReference entityReference { get; private set; }
+
+        public Guid Id
+        {
+            get => entityReference.Id;
+        }
+
+        public String Name
+        {
+            get => entityReference.Name ?? String.Empty;
+        }
+         public String LogicalName
+        {
+            get => entityReference.LogicalName ?? String.Empty;
+        }
+
+        public Owner(EntityReference entityRef)
+        {
+            entityReference = entityRef;
+        }
+
+    }
+}

--- a/NZ.XrmToolbox.PersonalArtefactManager/AppCode/Owner.cs
+++ b/NZ.XrmToolbox.PersonalArtefactManager/AppCode/Owner.cs
@@ -12,18 +12,17 @@ namespace NZ.XrmToolbox.PersonalArtefactManager.AppCode
             get => entityReference.Id;
         }
 
-        public String Name
-        {
-            get => entityReference.Name ?? String.Empty;
-        }
-         public String LogicalName
+        public String Name;
+
+        public String LogicalName
         {
             get => entityReference.LogicalName ?? String.Empty;
         }
 
-        public Owner(EntityReference entityRef)
+        public Owner(EntityReference entityRef, String name)
         {
             entityReference = entityRef;
+            Name = name;
         }
 
     }

--- a/NZ.XrmToolbox.PersonalArtefactManager/AppCode/OwnerManager.cs
+++ b/NZ.XrmToolbox.PersonalArtefactManager/AppCode/OwnerManager.cs
@@ -1,0 +1,100 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Windows.Forms;
+using Microsoft.Xrm.Sdk;
+using Microsoft.Xrm.Sdk.Query;
+using XrmToolBox.Extensibility;
+
+namespace NZ.XrmToolbox.PersonalArtefactManager.AppCode
+{
+    internal class OwnerManager
+    {
+        private readonly PluginContext _pluginContext;
+        public Owner[] Owners { get; private set; } = new Owner[] { };
+
+        public event EventHandler OwnerListUpdated;
+
+        public OwnerManager(PluginContext context)
+        {
+            _pluginContext = context;         
+        }
+
+        public void LoadSystemOwners()
+        {
+            _pluginContext.WorkAsync(new WorkAsyncInfo
+            {
+                Message = "Query list of systemusers",
+                Work = (worker, args) =>
+                {
+                    args.Result = _pluginContext.Service.RetrieveMultiple(new QueryExpression("systemuser")
+                    {
+                        Orders = { new OrderExpression("fullname", OrderType.Ascending) },
+                        PageInfo = { ReturnTotalRecordCount = true },
+                        ColumnSet = new ColumnSet("systemuserid", "isdisabled", "internalemailaddress", "fullname"),
+                        LinkEntities = { new LinkEntity("systemuser", "systemuserroles", "systemuserid", "systemuserid", JoinOperator.Inner) },
+                        Distinct = true
+                    });
+                },
+                PostWorkCallBack = (args) =>
+                {
+                    // Clear Owner list
+                    Owners = new Owner[] { };
+
+                    if (args.Error != null)
+                    {
+                        MessageBox.Show(args.Error.ToString(), "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                    }
+                    else
+                    {
+                        var resultSet = args.Result as EntityCollection;
+                        if (resultSet != null)
+                        {
+                            Owners = resultSet.Entities.Select(e => new Owner(e.ToEntityReference())).ToArray();
+                        }
+                    }
+                    // There might be a cleaner way to do this
+                    // Get the teams and add them to the list
+                    _pluginContext.WorkAsync(new WorkAsyncInfo
+                    {
+                        Message = "Query list of teams",
+                        Work = (worker, args) =>
+                        {
+                            args.Result = _pluginContext.Service.RetrieveMultiple(new QueryExpression("team")
+                            {
+                                Orders = { new OrderExpression("name", OrderType.Ascending) },
+                                PageInfo = { ReturnTotalRecordCount = true },
+                                ColumnSet = new ColumnSet("teamid", "isdisabled", "name"),
+                                Distinct = true
+                            });
+                        },
+                        PostWorkCallBack = (args) =>
+                        {
+                            if (args.Error != null)
+                            {
+                                MessageBox.Show(args.Error.ToString(), "Error", MessageBoxButtons.OK, MessageBoxIcon.Error);
+                            }
+                            else
+                            {
+                                var resultSet = args.Result as EntityCollection;
+                                if (resultSet != null)
+                                {
+                                    Teams = resultSet.Entities.Select(e => new Owner(e.ToEntityReference())).ToArray();
+                                    Owners = Owners.Concat(Teams).ToList();
+                                }
+                            }
+                            // Notify all subscribers
+                            OwnerListUpdated(this, null);
+                        }
+                    });
+                }
+            });
+        }
+
+        public void Invalidate()
+        {
+            Owners = new Owner[] {};
+            OwnerListUpdated(this, null);
+        }
+    }
+}

--- a/NZ.XrmToolbox.PersonalArtefactManager/AppCode/PersonalDashboardManager.cs
+++ b/NZ.XrmToolbox.PersonalArtefactManager/AppCode/PersonalDashboardManager.cs
@@ -60,7 +60,7 @@ namespace NZ.XrmToolbox.PersonalArtefactManager.AppCode
                         };
 
                         var newDashboardEntity = new Entity(dashboardEntity.LogicalName);
-                        newDashboardEntity.Attributes["ownerid"] = owner;
+                        newDashboardEntity.Attributes["ownerid"] = owner.entityReference;
                         foreach (var key in attribsToBeCopied)
                         {
                             if (dashboardEntity.Contains(key))
@@ -93,7 +93,7 @@ namespace NZ.XrmToolbox.PersonalArtefactManager.AppCode
             });
         }
 
-        public void Assign(IPersonalArtefact artefact, EntityReference newOwner)
+        public void Assign(IPersonalArtefact artefact, Owner newOwner)
         {
             var dashboardArtefact = (PersonalDashboard)artefact;
             var dashboardEntity = dashboardArtefact.Entity;
@@ -111,7 +111,7 @@ namespace NZ.XrmToolbox.PersonalArtefactManager.AppCode
                     {
                         var response = (AssignResponse)_pluginContext.Service.Execute(new AssignRequest()
                         {
-                            Assignee = newOwner,
+                            Assignee = newOwner.entityReference,
                             Target = dashboardEntity.ToEntityReference()
                         });
                     }
@@ -130,7 +130,7 @@ namespace NZ.XrmToolbox.PersonalArtefactManager.AppCode
                     }
                     else
                     {
-                        MessageBox.Show($"Personal Dashboard successfully assigned to user \"{newOwner.Fullname}\" ({newOwner.Email} / {newOwner.Id})", "Info", MessageBoxButtons.OK, MessageBoxIcon.None);
+                        MessageBox.Show($"Personal Dashboard successfully assigned to user \"{newOwner.LogicalName}\" ({newOwner.Name} / {newOwner.Id})", "Info", MessageBoxButtons.OK, MessageBoxIcon.None);
                     }
                 }
             });

--- a/NZ.XrmToolbox.PersonalArtefactManager/AppCode/PersonalDiagramManager.cs
+++ b/NZ.XrmToolbox.PersonalArtefactManager/AppCode/PersonalDiagramManager.cs
@@ -25,7 +25,7 @@ namespace NZ.XrmToolbox.PersonalArtefactManager.AppCode
 
         #region Interface implementation "IPersonalArtefactManager"
 
-        public void Duplicate(IPersonalArtefact artefact, User owner)
+        public void Duplicate(IPersonalArtefact artefact, Owner owner)
         {
             var diagramArtefact = (PersonalDiagram)artefact;
             var diagramEntity = diagramArtefact.Entity;
@@ -48,7 +48,7 @@ namespace NZ.XrmToolbox.PersonalArtefactManager.AppCode
                         };
 
                         var newDiagramEntity = new Entity(diagramEntity.LogicalName);
-                        newDiagramEntity.Attributes["ownerid"] = owner.Entity.ToEntityReference();
+                        newDiagramEntity.Attributes["ownerid"] = owner;
                         foreach (var key in attribsToBeCopied)
                         {
                             if (diagramEntity.Contains(key))
@@ -81,7 +81,7 @@ namespace NZ.XrmToolbox.PersonalArtefactManager.AppCode
             });
         }
 
-        public void Assign(IPersonalArtefact artefact, User newOwner)
+        public void Assign(IPersonalArtefact artefact, Owner newOwner)
         {
             var diagramArtefact = (PersonalDiagram)artefact;
             var diagramEntity = diagramArtefact.Entity;
@@ -99,8 +99,8 @@ namespace NZ.XrmToolbox.PersonalArtefactManager.AppCode
                     {
                         var response = (AssignResponse)_pluginContext.Service.Execute(new AssignRequest()
                         {
-                            Assignee = newOwner.Entity.ToEntityReference(),
-                            Target = diagramEntity .ToEntityReference()
+                            Assignee = newOwner,
+                            Target = diagramEntity.ToEntityReference()
                         });
                     }
                     catch (Exception exc)
@@ -118,7 +118,7 @@ namespace NZ.XrmToolbox.PersonalArtefactManager.AppCode
                     }
                     else
                     {
-                        MessageBox.Show($"Personal Diagram successfully assigned to user \"{newOwner.Fullname}\" ({newOwner.Email} / {newOwner.Id})", "Info", MessageBoxButtons.OK, MessageBoxIcon.None);
+                        MessageBox.Show($"Personal Diagram successfully assigned to user \"{newOwner.LogicalName}\" ({newOwner.Name} / {newOwner.Id})", "Info", MessageBoxButtons.OK, MessageBoxIcon.None);
                     }
                 }
             });
@@ -167,15 +167,15 @@ namespace NZ.XrmToolbox.PersonalArtefactManager.AppCode
         }
 
         /// <summary>
-        /// Query personal artefacts for given User
+        /// Query personal artefacts for given Owner
         /// </summary>
-        /// <param name="user" type="User"></param>
-        public void QueryByUser(User user)
+        /// <param name="owner" type="Owner"></param>
+        public void QueryByUser(Owner owner)
         {                               
-            // Clear user list
+            // Clear owner list
             ReplaceDiagrams(Array.Empty<Entity>());
 
-            if (user == null) return;
+            if (owner == null) return;
 
             _pluginContext.WorkAsync(new WorkAsyncInfo
             {
@@ -184,7 +184,7 @@ namespace NZ.XrmToolbox.PersonalArtefactManager.AppCode
                 {
                     var client = _pluginContext.ConnectionDetail.GetCrmServiceClient();
                     var userIdBefore = client.CallerId;
-                    client.CallerId = user.Id;
+                    client.CallerId = owner.Id;
 
                     try
                     {
@@ -195,7 +195,7 @@ namespace NZ.XrmToolbox.PersonalArtefactManager.AppCode
                             ColumnSet = new ColumnSet(true),
                             Criteria = new FilterExpression
                             {
-                                Conditions = {new ConditionExpression("ownerid", ConditionOperator.Equal, user.Id)}
+                                Conditions = {new ConditionExpression("ownerid", ConditionOperator.Equal, owner.Id)}
                             }
                         });
                     }

--- a/NZ.XrmToolbox.PersonalArtefactManager/AppCode/PersonalDiagramManager.cs
+++ b/NZ.XrmToolbox.PersonalArtefactManager/AppCode/PersonalDiagramManager.cs
@@ -48,7 +48,7 @@ namespace NZ.XrmToolbox.PersonalArtefactManager.AppCode
                         };
 
                         var newDiagramEntity = new Entity(diagramEntity.LogicalName);
-                        newDiagramEntity.Attributes["ownerid"] = owner;
+                        newDiagramEntity.Attributes["ownerid"] = owner.entityReference;
                         foreach (var key in attribsToBeCopied)
                         {
                             if (diagramEntity.Contains(key))
@@ -75,7 +75,7 @@ namespace NZ.XrmToolbox.PersonalArtefactManager.AppCode
                     {
                         var newRecordId = (Guid) args.Result;
                         Clipboard.SetText(newRecordId.ToString());
-                        MessageBox.Show($"Personal Diagram successfully duplicated and assigned to user \"{owner.Fullname}\" ({owner.Email} / {owner.Id}). New record Id was copied to clipboard ({newRecordId.ToString()})", "Info", MessageBoxButtons.OK, MessageBoxIcon.None);
+                        MessageBox.Show($"Personal Diagram successfully duplicated and assigned to user \"{owner.LogicalName}\" ({owner.Name} / {owner.Id}). New record Id was copied to clipboard ({newRecordId.ToString()})", "Info", MessageBoxButtons.OK, MessageBoxIcon.None);
                     }
                 }
             });
@@ -99,7 +99,7 @@ namespace NZ.XrmToolbox.PersonalArtefactManager.AppCode
                     {
                         var response = (AssignResponse)_pluginContext.Service.Execute(new AssignRequest()
                         {
-                            Assignee = newOwner,
+                            Assignee = newOwner.entityReference,
                             Target = diagramEntity.ToEntityReference()
                         });
                     }
@@ -170,7 +170,7 @@ namespace NZ.XrmToolbox.PersonalArtefactManager.AppCode
         /// Query personal artefacts for given Owner
         /// </summary>
         /// <param name="owner" type="Owner"></param>
-        public void QueryByUser(Owner owner)
+        public void QueryByOwner(Owner owner)
         {                               
             // Clear owner list
             ReplaceDiagrams(Array.Empty<Entity>());

--- a/NZ.XrmToolbox.PersonalArtefactManager/AppCode/PersonalViewManager.cs
+++ b/NZ.XrmToolbox.PersonalArtefactManager/AppCode/PersonalViewManager.cs
@@ -29,7 +29,7 @@ namespace NZ.XrmToolbox.PersonalArtefactManager.AppCode
 
         #region Interface implementation "IPersonalArtefactManager"
 
-        public void Duplicate(IPersonalArtefact artefact, User owner)
+        public void Duplicate(IPersonalArtefact artefact, Owner owner)
         {
             var viewArtefact = (PersonalView)artefact;
             var viewEntity = viewArtefact.Entity;
@@ -54,7 +54,7 @@ namespace NZ.XrmToolbox.PersonalArtefactManager.AppCode
                         };
 
                         var newViewEntity = new Entity(viewEntity.LogicalName);
-                        newViewEntity.Attributes["ownerid"] = owner.Entity.ToEntityReference();
+                        newViewEntity.Attributes["ownerid"] = owner;
                         foreach (var key in attribsToBeCopied)
                         {
                             if (viewEntity.Contains(key))
@@ -81,13 +81,13 @@ namespace NZ.XrmToolbox.PersonalArtefactManager.AppCode
                     {
                         var newRecordId = (Guid) args.Result;
                         Clipboard.SetText(newRecordId.ToString());
-                        MessageBox.Show($"Personal View successfully assigned to user \"{owner.Fullname}\" ({owner.Email} / {owner.Id}). New record Id was copied to clipboard ({newRecordId.ToString()})", "Info", MessageBoxButtons.OK, MessageBoxIcon.None);
+                        MessageBox.Show($"Personal View successfully assigned to user \"{owner.LogicalName}\" ({owner.Name} / {owner.Id}). New record Id was copied to clipboard ({newRecordId.ToString()})", "Info", MessageBoxButtons.OK, MessageBoxIcon.None);
                     }
                 }
             });
         }
 
-        public void Assign(IPersonalArtefact artefact, User newOwner)
+        public void Assign(IPersonalArtefact artefact, Owner newOwner)
         {
             var viewArtefact = (PersonalView)artefact;
             var viewEntity = viewArtefact.Entity;
@@ -105,8 +105,8 @@ namespace NZ.XrmToolbox.PersonalArtefactManager.AppCode
                     {
                         var response = (AssignResponse)_pluginContext.Service.Execute(new AssignRequest()
                         {
-                            Assignee = newOwner.Entity.ToEntityReference(),
-                            Target = viewEntity .ToEntityReference()
+                            Assignee = newOwner,
+                            Target = viewEntity.ToEntityReference()
                         });
                     }
                     catch (Exception exc)
@@ -124,7 +124,7 @@ namespace NZ.XrmToolbox.PersonalArtefactManager.AppCode
                     }
                     else
                     {
-                        MessageBox.Show($"Personal View successfully assigned to user \"{newOwner.Fullname}\" ({newOwner.Email} / {newOwner.Id})", "Info", MessageBoxButtons.OK, MessageBoxIcon.None);
+                        MessageBox.Show($"Personal View successfully assigned to user \"{newOwner.LogicalName}\" ({newOwner.Name} / {newOwner.Id})", "Info", MessageBoxButtons.OK, MessageBoxIcon.None);
                     }
                 }
             });
@@ -175,13 +175,13 @@ namespace NZ.XrmToolbox.PersonalArtefactManager.AppCode
         /// <summary>
         /// Query personal artefacts for given User
         /// </summary>
-        /// <param name="user" type="User"></param>
-        public void QueryByUser(User user)
+        /// <param name="owner" type="Owner"></param>
+        public void QueryByUser(Owner user)
         {                               
-            // Clear user list
+            // Clear owner list
             ReplaceViews(Array.Empty<Entity>());
 
-            if (user == null) return;
+            if (owner == null) return;
 
             _pluginContext.WorkAsync(new WorkAsyncInfo
             {
@@ -190,7 +190,7 @@ namespace NZ.XrmToolbox.PersonalArtefactManager.AppCode
                 {
                     var client = _pluginContext.ConnectionDetail.GetCrmServiceClient();
                     var userIdBefore = client.CallerId;
-                    client.CallerId = user.Id;
+                    client.CallerId = owner.Id;
 
                     try
                     {
@@ -203,7 +203,7 @@ namespace NZ.XrmToolbox.PersonalArtefactManager.AppCode
                             {
                                 Conditions =
                                 {
-                                    new ConditionExpression("ownerid", ConditionOperator.Equal, user.Id),
+                                    new ConditionExpression("ownerid", ConditionOperator.Equal, owner.Id),
                                     // Only respect userqueries manually created by users
                                     new ConditionExpression("querytype", ConditionOperator.Equal, UserQueryQueryType.MainApplicationView)
                                 }

--- a/NZ.XrmToolbox.PersonalArtefactManager/AppCode/PersonalViewManager.cs
+++ b/NZ.XrmToolbox.PersonalArtefactManager/AppCode/PersonalViewManager.cs
@@ -54,7 +54,7 @@ namespace NZ.XrmToolbox.PersonalArtefactManager.AppCode
                         };
 
                         var newViewEntity = new Entity(viewEntity.LogicalName);
-                        newViewEntity.Attributes["ownerid"] = owner;
+                        newViewEntity.Attributes["ownerid"] = owner.entityReference;
                         foreach (var key in attribsToBeCopied)
                         {
                             if (viewEntity.Contains(key))
@@ -105,7 +105,7 @@ namespace NZ.XrmToolbox.PersonalArtefactManager.AppCode
                     {
                         var response = (AssignResponse)_pluginContext.Service.Execute(new AssignRequest()
                         {
-                            Assignee = newOwner,
+                            Assignee = newOwner.entityReference,
                             Target = viewEntity.ToEntityReference()
                         });
                     }
@@ -176,7 +176,7 @@ namespace NZ.XrmToolbox.PersonalArtefactManager.AppCode
         /// Query personal artefacts for given User
         /// </summary>
         /// <param name="owner" type="Owner"></param>
-        public void QueryByUser(Owner user)
+        public void QueryByOwner(Owner owner)
         {                               
             // Clear owner list
             ReplaceViews(Array.Empty<Entity>());

--- a/NZ.XrmToolbox.PersonalArtefactManager/NZ.XrmToolbox.PersonalArtefactManager.csproj
+++ b/NZ.XrmToolbox.PersonalArtefactManager/NZ.XrmToolbox.PersonalArtefactManager.csproj
@@ -35,26 +35,26 @@
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <PropertyGroup>
-    <AssemblyOriginatorKeyFile>NZ Keyfile.pfx</AssemblyOriginatorKeyFile>
+    <AssemblyOriginatorKeyFile>MK Signature.pfx</AssemblyOriginatorKeyFile>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="McTools.Xrm.Connection, Version=1.2017.10.15, Culture=neutral, PublicKeyToken=96037217801d9658, processorArchitecture=MSIL">
-      <HintPath>..\packages\MscrmTools.Xrm.Connection.1.2017.10.15\lib\net462\McTools.Xrm.Connection.dll</HintPath>
+    <Reference Include="McTools.Xrm.Connection, Version=1.2021.6.44, Culture=neutral, PublicKeyToken=96037217801d9658, processorArchitecture=MSIL">
+      <HintPath>..\packages\MscrmTools.Xrm.Connection.1.2021.6.44\lib\net462\McTools.Xrm.Connection.dll</HintPath>
     </Reference>
-    <Reference Include="McTools.Xrm.Connection.WinForms, Version=1.2017.10.15, Culture=neutral, PublicKeyToken=f1559f79cf894e27, processorArchitecture=MSIL">
-      <HintPath>..\packages\MscrmTools.Xrm.Connection.1.2017.10.15\lib\net462\McTools.Xrm.Connection.WinForms.dll</HintPath>
+    <Reference Include="McTools.Xrm.Connection.WinForms, Version=1.2021.6.44, Culture=neutral, PublicKeyToken=f1559f79cf894e27, processorArchitecture=MSIL">
+      <HintPath>..\packages\MscrmTools.Xrm.Connection.1.2021.6.44\lib\net462\McTools.Xrm.Connection.WinForms.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Crm.Sdk.Proxy, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.0.7\lib\net452\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.25\lib\net462\Microsoft.Crm.Sdk.Proxy.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.IdentityModel, Version=3.5.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.IdentityModel.6.1.7600.16394\lib\net35\Microsoft.IdentityModel.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=2.29.0.1078, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.2.29.0\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
+    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory, Version=5.2.8.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.5.2.8\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms, Version=2.29.0.1078, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.IdentityModel.Clients.ActiveDirectory.2.29.0\lib\net45\Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms.dll</HintPath>
+    <Reference Include="Microsoft.Rest.ClientRuntime, Version=2.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CrmSdk.XrmTooling.CoreAssembly.9.1.0.79\lib\net462\Microsoft.Rest.ClientRuntime.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Web.XmlTransform, Version=2.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Web.Xdt.2.1.1\lib\net40\Microsoft.Web.XmlTransform.dll</HintPath>
@@ -63,22 +63,52 @@
       <HintPath>..\packages\Microsoft.Win32.Primitives.4.0.1\lib\net46\Microsoft.Win32.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.0.7\lib\net452\Microsoft.Xrm.Sdk.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CrmSdk.CoreAssemblies.9.0.2.25\lib\net462\Microsoft.Xrm.Sdk.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk.Deployment, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.Deployment.9.0.0.7\lib\net452\Microsoft.Xrm.Sdk.Deployment.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CrmSdk.Deployment.9.0.2.25\lib\net462\Microsoft.Xrm.Sdk.Deployment.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.Xrm.Sdk.Workflow, Version=9.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.Workflow.9.0.0.7\lib\net452\Microsoft.Xrm.Sdk.Workflow.dll</HintPath>
+      <HintPath>..\packages\Microsoft.CrmSdk.Workflow.9.0.2.25\lib\net462\Microsoft.Xrm.Sdk.Workflow.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.Xrm.Tooling.Connector, Version=3.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.CrmSdk.XrmTooling.CoreAssembly.9.0.0.7\lib\net452\Microsoft.Xrm.Tooling.Connector.dll</HintPath>
+    <Reference Include="Microsoft.Xrm.Tooling.Connector, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CrmSdk.XrmTooling.CoreAssembly.9.1.0.79\lib\net462\Microsoft.Xrm.Tooling.Connector.dll</HintPath>
     </Reference>
-    <Reference Include="Newtonsoft.Json, Version=9.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
-      <HintPath>..\packages\Newtonsoft.Json.9.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    <Reference Include="Microsoft.Xrm.Tooling.CrmConnectControl, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CrmSdk.XrmTooling.WpfControls.9.1.0.68\lib\net462\Microsoft.Xrm.Tooling.CrmConnectControl.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Xrm.Tooling.Ui.Styles, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CrmSdk.XrmTooling.WpfControls.9.1.0.68\lib\net462\Microsoft.Xrm.Tooling.Ui.Styles.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Xrm.Tooling.WebResourceUtility, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.CrmSdk.XrmTooling.WpfControls.9.1.0.68\lib\net462\Microsoft.Xrm.Tooling.WebResourceUtility.dll</HintPath>
+    </Reference>
+    <Reference Include="Newtonsoft.Json, Version=13.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
+      <HintPath>..\packages\Newtonsoft.Json.13.0.1\lib\net45\Newtonsoft.Json.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.Common, Version=5.10.0.7240, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\NuGet.Common.5.10.0\lib\net45\NuGet.Common.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.Configuration, Version=5.10.0.7240, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\NuGet.Configuration.5.10.0\lib\net45\NuGet.Configuration.dll</HintPath>
     </Reference>
     <Reference Include="NuGet.Core, Version=2.14.0.832, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\NuGet.Core.2.14.0\lib\net40-Client\NuGet.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.Frameworks, Version=5.10.0.7240, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\NuGet.Frameworks.5.10.0\lib\net40\NuGet.Frameworks.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.Packaging, Version=5.10.0.7240, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\NuGet.Packaging.5.10.0\lib\netstandard2.0\NuGet.Packaging.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.Protocol, Version=5.10.0.7240, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\NuGet.Protocol.5.10.0\lib\netstandard2.0\NuGet.Protocol.dll</HintPath>
+    </Reference>
+    <Reference Include="NuGet.Versioning, Version=5.10.0.7240, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\NuGet.Versioning.5.10.0\lib\net45\NuGet.Versioning.dll</HintPath>
+    </Reference>
+    <Reference Include="ScintillaNET, Version=3.6.3.0, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\jacobslusser.ScintillaNET.3.6.3\lib\net40\ScintillaNET.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -88,9 +118,14 @@
     <Reference Include="System.IO, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.IO.4.1.0\lib\net462\System.IO.dll</HintPath>
     </Reference>
-    <Reference Include="System.Net.Http, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Net.Http.4.1.0\lib\net46\System.Net.Http.dll</HintPath>
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Net" />
+    <Reference Include="System.Net.Http, Version=4.1.1.3, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Net.Http.4.3.4\lib\net46\System.Net.Http.dll</HintPath>
+      <Private>True</Private>
+      <Private>True</Private>
     </Reference>
+    <Reference Include="System.Net.Http.WebRequest" />
     <Reference Include="System.Reflection, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\System.Reflection.4.1.0\lib\net462\System.Reflection.dll</HintPath>
     </Reference>
@@ -107,18 +142,24 @@
       <HintPath>..\packages\System.Runtime.Serialization.Primitives.4.1.1\lib\net46\System.Runtime.Serialization.Primitives.dll</HintPath>
     </Reference>
     <Reference Include="System.Security.Cryptography.Algorithms, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.2.0\lib\net461\System.Security.Cryptography.Algorithms.dll</HintPath>
+      <HintPath>..\packages\System.Security.Cryptography.Algorithms.4.3.1\lib\net461\System.Security.Cryptography.Algorithms.dll</HintPath>
     </Reference>
-    <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Cryptography.Encoding.4.0.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+    <Reference Include="System.Security.Cryptography.Cng, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Cng.5.0.0\lib\net462\System.Security.Cryptography.Cng.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Encoding, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Encoding.4.3.0\lib\net46\System.Security.Cryptography.Encoding.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Pkcs, Version=5.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Pkcs.5.0.0\lib\net461\System.Security.Cryptography.Pkcs.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.Primitives.4.3.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
+    </Reference>
+    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.1.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.3.0\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
       <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Security.Cryptography.Primitives, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Cryptography.Primitives.4.0.0\lib\net46\System.Security.Cryptography.Primitives.dll</HintPath>
       <Private>True</Private>
-    </Reference>
-    <Reference Include="System.Security.Cryptography.X509Certificates, Version=4.1.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.Security.Cryptography.X509Certificates.4.1.0\lib\net461\System.Security.Cryptography.X509Certificates.dll</HintPath>
     </Reference>
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -148,17 +189,23 @@
     <Reference Include="System.Workflow.Activities" />
     <Reference Include="System.Workflow.ComponentModel" />
     <Reference Include="System.Workflow.Runtime" />
-    <Reference Include="XrmToolBox">
-      <HintPath>..\packages\XrmToolBoxPackage.1.2017.11.20\lib\net462\XrmToolBox.exe</HintPath>
-      <Private>True</Private>
+    <Reference Include="WeifenLuo.WinFormsUI.Docking, Version=3.0.6.0, Culture=neutral, PublicKeyToken=5cded1a1a0a7b481, processorArchitecture=MSIL">
+      <HintPath>..\packages\DockPanelSuite.3.0.6\lib\net40\WeifenLuo.WinFormsUI.Docking.dll</HintPath>
     </Reference>
-    <Reference Include="XrmToolBox.Extensibility">
-      <HintPath>..\packages\XrmToolBoxPackage.1.2017.11.20\lib\net462\XrmToolBox.Extensibility.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="WeifenLuo.WinFormsUI.Docking.ThemeVS2015, Version=3.0.6.0, Culture=neutral, PublicKeyToken=5cded1a1a0a7b481, processorArchitecture=MSIL">
+      <HintPath>..\packages\DockPanelSuite.ThemeVS2015.3.0.6\lib\net40\WeifenLuo.WinFormsUI.Docking.ThemeVS2015.dll</HintPath>
     </Reference>
-    <Reference Include="XrmToolBox.PluginsStore">
-      <HintPath>..\packages\XrmToolBoxPackage.1.2017.11.20\lib\net462\XrmToolBox.PluginsStore.dll</HintPath>
-      <Private>True</Private>
+    <Reference Include="XrmToolBox, Version=1.2021.5.47, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\XrmToolBoxPackage.1.2021.5.47\lib\net462\XrmToolBox.exe</HintPath>
+    </Reference>
+    <Reference Include="XrmToolBox.AutoUpdater, Version=1.1.0.2, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\XrmToolBoxPackage.1.2021.5.47\lib\net462\XrmToolBox.AutoUpdater.exe</HintPath>
+    </Reference>
+    <Reference Include="XrmToolBox.Extensibility, Version=1.2021.5.47, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\XrmToolBoxPackage.1.2021.5.47\lib\net462\XrmToolBox.Extensibility.dll</HintPath>
+    </Reference>
+    <Reference Include="XrmToolBox.PluginsStore, Version=1.2021.5.47, Culture=neutral, processorArchitecture=MSIL">
+      <HintPath>..\packages\XrmToolBoxPackage.1.2021.5.47\lib\net462\XrmToolBox.PluginsStore.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -205,6 +252,7 @@
   </ItemGroup>
   <ItemGroup>
     <None Include="app.config" />
+    <None Include="MK Signature.pfx" />
     <None Include="NZ Keyfile.pfx" />
     <None Include="packages.config" />
   </ItemGroup>

--- a/NZ.XrmToolbox.PersonalArtefactManager/NZ.XrmToolbox.PersonalArtefactManager.csproj
+++ b/NZ.XrmToolbox.PersonalArtefactManager/NZ.XrmToolbox.PersonalArtefactManager.csproj
@@ -169,7 +169,7 @@
     <Compile Include="AppCode\Form\ListViewItemSorter.cs" />
     <Compile Include="AppCode\Form\PersonalDashboardListViewBuilder.cs" />
     <Compile Include="AppCode\Form\PersonalDiagramListViewBuilder.cs" />
-    <Compile Include="AppCode\Form\UserListViewBuilder.cs" />
+    <Compile Include="AppCode\Form\OwnerListViewBuilder.cs" />
     <Compile Include="AppCode\IPersonalArtefact.cs" />
     <Compile Include="AppCode\IPersonalArtefactManager.cs" />
     <Compile Include="AppCode\Form\ListViewBuilder.cs" />
@@ -184,8 +184,8 @@
     <Compile Include="AppCode\PersonalViewManager.cs" />
     <Compile Include="AppCode\PluginContext.cs" />
     <Compile Include="AppCode\UnknownArtefactTypeError.cs" />
-    <Compile Include="AppCode\User.cs" />
-    <Compile Include="AppCode\UserManager.cs" />
+    <Compile Include="AppCode\Owner.cs" />
+    <Compile Include="AppCode\OwnerManager.cs" />
     <Compile Include="AppCode\Helpers\ErrorHelper.cs" />
     <Compile Include="AppCode\Form\ComboBoxItem.cs" />
     <Compile Include="PersonalArtefactManager.cs" />

--- a/NZ.XrmToolbox.PersonalArtefactManager/PersonalArtefactManagerControl.cs
+++ b/NZ.XrmToolbox.PersonalArtefactManager/PersonalArtefactManagerControl.cs
@@ -15,7 +15,7 @@ namespace NZ.XrmToolbox.PersonalArtefactManager
         private Settings _pluginSettings;
         private PluginContext _pluginCtx;
         private OwnerManager _ownerManager;
-        private UserListViewBuilder _userListViewBuilder;
+        private OwnerListViewBuilder _ownerListViewBuilder;
         private ArtefactManagerFactory _artefactManagerFactory;
 
         private bool _isPluginLoaded = false;
@@ -86,8 +86,8 @@ namespace NZ.XrmToolbox.PersonalArtefactManager
         public event EventHandler<StatusBarMessageEventArgs> SendMessageToStatusBar;
         internal event EventHandler<ArtefactTypeSelectedEventArgs> PersonalArtifactTypeSelected;
         internal event EventHandler PersonalArtifactSelected;
-        internal event EventHandler<UserSelectedEventArgs> SourceUserSelected;
-        internal event EventHandler<UserSelectedEventArgs> TargetUserSelected;
+        internal event EventHandler<OwnerSelectedEventArgs> SourceUserSelected;
+        internal event EventHandler<OwnerSelectedEventArgs> TargetUserSelected;
 
         #endregion
 
@@ -122,8 +122,8 @@ namespace NZ.XrmToolbox.PersonalArtefactManager
             }
 
             _pluginCtx = new PluginContext(this);
-            _ownerManager = new UserManager(_pluginCtx);
-            _userListViewBuilder = new UserListViewBuilder();
+            _ownerManager = new OwnerManager(_pluginCtx);
+            _ownerListViewBuilder = new OwnerListViewBuilder();
             _artefactManagerFactory = new ArtefactManagerFactory(_pluginCtx); 
 
             // Initialize controls
@@ -140,7 +140,7 @@ namespace NZ.XrmToolbox.PersonalArtefactManager
             });
 
             // Wire up application event handlers
-            _ownerManager.UserListUpdated += OnUserManagerOnUserListUpdated;
+            _ownerManager.OwnerListUpdated += OnOwnerManagerOnUserListUpdated;
             _artefactManagerFactory.ArtefactListUpdated += OnArtefactListUpdated;
             PersonalArtifactTypeSelected += OnArtefactTypeSelected;
             SourceUserSelected += OnSourceUserSelected;
@@ -164,15 +164,15 @@ namespace NZ.XrmToolbox.PersonalArtefactManager
             btnDoMigration.Enabled = IsFormStateReadyForProcessing;
         }
 
-        private void OnUserManagerOnUserListUpdated(object evtSender, EventArgs evt)
+        private void OnOwnerManagerOnUserListUpdated(object evtSender, EventArgs evt)
         {
             lblSourceUsersStatus.Text = lblTargetUsersStatus.Text = $"{_ownerManager.Owners.Length} owners found";
             // Populate list of source users
-            _userListViewBuilder.HasCheckboxes = false;
-            _userListViewBuilder.BuildList(lvSourceUsers, _ownerManager.Owners);
+            _ownerListViewBuilder.HasCheckboxes = false;
+            _ownerListViewBuilder.BuildList(lvSourceUsers, _ownerManager.Owners);
             // Populate list of target users
-            _userListViewBuilder.HasCheckboxes = true;
-            _userListViewBuilder.BuildList(lvTargetUsers, _ownerManager.Owners);
+            _ownerListViewBuilder.HasCheckboxes = true;
+            _ownerListViewBuilder.BuildList(lvTargetUsers, _ownerManager.Owners);
             // Update visibility state
             lvSourceUsers.Enabled = true;
             cbArtefactTypeSelector.Enabled = true;
@@ -180,7 +180,7 @@ namespace NZ.XrmToolbox.PersonalArtefactManager
             btnDoMigration.Enabled = IsFormStateReadyForProcessing;
         }
 
-        private void OnSourceUserSelected(object evtSender, UserSelectedEventArgs evt)
+        private void OnSourceUserSelected(object evtSender, OwnerSelectedEventArgs evt)
         {
             if (_artefactManagerFactory.IsKnownType(SelectedArtefactTypeName) == false || SelectedSourceOwner == null)
             {
@@ -266,7 +266,7 @@ namespace NZ.XrmToolbox.PersonalArtefactManager
             selectedOwners.Add(selectedItem?.Tag as Owner);
             selectedOwners.RemoveAll(u => u == null);
             // Trigger event
-            SourceUserSelected(this, new UserSelectedEventArgs(selectedOwners.ToArray()));
+            SourceUserSelected(this, new OwnerSelectedEventArgs(selectedOwners.ToArray()));
         }
 
         private void cbArtefactTypeSelector_SelectedIndexChanged(object sender, EventArgs e)

--- a/NZ.XrmToolbox.PersonalArtefactManager/PersonalArtefactManagerControl.cs
+++ b/NZ.XrmToolbox.PersonalArtefactManager/PersonalArtefactManagerControl.cs
@@ -14,7 +14,7 @@ namespace NZ.XrmToolbox.PersonalArtefactManager
     {
         private Settings _pluginSettings;
         private PluginContext _pluginCtx;
-        private UserManager _userManager;
+        private OwnerManager _ownerManager;
         private UserListViewBuilder _userListViewBuilder;
         private ArtefactManagerFactory _artefactManagerFactory;
 
@@ -24,8 +24,8 @@ namespace NZ.XrmToolbox.PersonalArtefactManager
             get {
                 return btnDoMigration.Enabled = (SelectedOperation != null) 
                     && (SelectedCrmArtefacts.Length > 0)
-                    && (SelectedSourceUser != null)
-                    && (SelectedTargetUsers.Length > 0 || SelectedOperation == PluginOperation.Delete);
+                    && (SelectedSourceOwner != null)
+                    && (SelectedTargetOwners.Length > 0 || SelectedOperation == PluginOperation.Delete);
             }
         }
 
@@ -60,24 +60,24 @@ namespace NZ.XrmToolbox.PersonalArtefactManager
                 return selectedOp;
             }
         }
-        private User SelectedSourceUser
+        private Owner SelectedSourceOwner
         {
             get
             {
                 return (lvSourceUsers.SelectedItems.Count == 0)
-                    ? null : (lvSourceUsers.SelectedItems[0]?.Tag as User);
+                    ? null : (lvSourceUsers.SelectedItems[0]?.Tag as Owner);
             }
         }
-        private User[] SelectedTargetUsers
+        private Owner[] SelectedTargetOwners
         {
             get
             {
-                var selUsers = new List<User>();
+                var selOwners = new List<Owner>();
                 foreach (ListViewItem item in lvTargetUsers.CheckedItems)
                 {
-                    selUsers.Add((User)item.Tag);
+                    selOwners.Add((Owner)item.Tag);
                 }
-                return selUsers.ToArray();
+                return selOwners.ToArray();
             }
         }
 
@@ -122,7 +122,7 @@ namespace NZ.XrmToolbox.PersonalArtefactManager
             }
 
             _pluginCtx = new PluginContext(this);
-            _userManager = new UserManager(_pluginCtx);
+            _ownerManager = new UserManager(_pluginCtx);
             _userListViewBuilder = new UserListViewBuilder();
             _artefactManagerFactory = new ArtefactManagerFactory(_pluginCtx); 
 
@@ -140,7 +140,7 @@ namespace NZ.XrmToolbox.PersonalArtefactManager
             });
 
             // Wire up application event handlers
-            _userManager.UserListUpdated += OnUserManagerOnUserListUpdated;
+            _ownerManager.UserListUpdated += OnUserManagerOnUserListUpdated;
             _artefactManagerFactory.ArtefactListUpdated += OnArtefactListUpdated;
             PersonalArtifactTypeSelected += OnArtefactTypeSelected;
             SourceUserSelected += OnSourceUserSelected;
@@ -166,13 +166,13 @@ namespace NZ.XrmToolbox.PersonalArtefactManager
 
         private void OnUserManagerOnUserListUpdated(object evtSender, EventArgs evt)
         {
-            lblSourceUsersStatus.Text = lblTargetUsersStatus.Text = $"{_userManager.Users.Length} users found";
+            lblSourceUsersStatus.Text = lblTargetUsersStatus.Text = $"{_ownerManager.Owners.Length} owners found";
             // Populate list of source users
             _userListViewBuilder.HasCheckboxes = false;
-            _userListViewBuilder.BuildList(lvSourceUsers, _userManager.Users);
+            _userListViewBuilder.BuildList(lvSourceUsers, _ownerManager.Owners);
             // Populate list of target users
             _userListViewBuilder.HasCheckboxes = true;
-            _userListViewBuilder.BuildList(lvTargetUsers, _userManager.Users);
+            _userListViewBuilder.BuildList(lvTargetUsers, _ownerManager.Owners);
             // Update visibility state
             lvSourceUsers.Enabled = true;
             cbArtefactTypeSelector.Enabled = true;
@@ -182,7 +182,7 @@ namespace NZ.XrmToolbox.PersonalArtefactManager
 
         private void OnSourceUserSelected(object evtSender, UserSelectedEventArgs evt)
         {
-            if (_artefactManagerFactory.IsKnownType(SelectedArtefactTypeName) == false || SelectedSourceUser == null)
+            if (_artefactManagerFactory.IsKnownType(SelectedArtefactTypeName) == false || SelectedSourceOwner == null)
             {
                 lvCrmArtefacts.Items.Clear();
                 lvCrmArtefacts.Enabled = true;
@@ -197,7 +197,7 @@ namespace NZ.XrmToolbox.PersonalArtefactManager
         
         private void OnArtefactTypeSelected(object evtSender, ArtefactTypeSelectedEventArgs evt)
         {
-            if (SelectedSourceUser == null || !_artefactManagerFactory.IsKnownType(SelectedArtefactTypeName))
+            if (SelectedSourceOwner == null || !_artefactManagerFactory.IsKnownType(SelectedArtefactTypeName))
             {
                 lvCrmArtefacts.Items.Clear();
                 lvCrmArtefacts.Enabled = true;
@@ -254,7 +254,7 @@ namespace NZ.XrmToolbox.PersonalArtefactManager
             // Disable list views while loading
             lvSourceUsers.Enabled = lvCrmArtefacts.Enabled = lvTargetUsers.Enabled = false;
             // Invoke user re-load
-            ExecuteMethod(LoadCrmUsers);
+            ExecuteMethod(LoadCrmOwners);
         }
 
         
@@ -262,11 +262,11 @@ namespace NZ.XrmToolbox.PersonalArtefactManager
         private void lvSourceUsers_SelectedIndexChanged(object sender, EventArgs e)
         {
             var selectedItem = lvSourceUsers.SelectedItems.Count == 0 ? null : lvSourceUsers.SelectedItems[0];
-            var selectedUsers = new List<User>();
-            selectedUsers.Add(selectedItem?.Tag as User);
-            selectedUsers.RemoveAll(u => u == null);
+            var selectedOwners = new List<Owner>();
+            selectedOwners.Add(selectedItem?.Tag as Owner);
+            selectedOwners.RemoveAll(u => u == null);
             // Trigger event
-            SourceUserSelected(this, new UserSelectedEventArgs(selectedUsers.ToArray()));
+            SourceUserSelected(this, new UserSelectedEventArgs(selectedOwners.ToArray()));
         }
 
         private void cbArtefactTypeSelector_SelectedIndexChanged(object sender, EventArgs e)
@@ -285,8 +285,8 @@ namespace NZ.XrmToolbox.PersonalArtefactManager
 
         private void btnDoMigration_Click(object sender, EventArgs e)
         {
-            if ((SelectedOperation == null) || (SelectedCrmArtefacts.Length == 0) || (SelectedSourceUser == null) ||
-                (SelectedTargetUsers.Length == 0 && SelectedOperation != PluginOperation.Delete))
+            if ((SelectedOperation == null) || (SelectedCrmArtefacts.Length == 0) || (SelectedSourceOwner == null) ||
+                (SelectedTargetOwners.Length == 0 && SelectedOperation != PluginOperation.Delete))
             {
                 return;
             }
@@ -326,13 +326,13 @@ namespace NZ.XrmToolbox.PersonalArtefactManager
             }
             else
             {
-                var nUnitsOfWork = lvCrmArtefacts.CheckedItems.Count * SelectedTargetUsers.Length;
+                var nUnitsOfWork = lvCrmArtefacts.CheckedItems.Count * SelectedTargetOwners.Length;
                 var nUnitsOfWorkDone = 0;
                 var percentagePerUnit = 100 / nUnitsOfWork;
 
                 SendMessageToStatusBar?.Invoke(this, new StatusBarMessageEventArgs(nUnitsOfWorkDone, $"Processing {nUnitsOfWork} artefacts"));
                 // Iterate through all possible artefact-user combinations and process
-                foreach (var targetUser in SelectedTargetUsers)
+                foreach (var targetUser in SelectedTargetOwners)
                 {
                     foreach (ListViewItem item in lvCrmArtefacts.CheckedItems)
                     {
@@ -365,14 +365,14 @@ namespace NZ.XrmToolbox.PersonalArtefactManager
             lvSourceUsers.Enabled = lvCrmArtefacts.Enabled = lvTargetUsers.Enabled = false;
         }
 
-        private void LoadCrmUsers()
+        private void LoadCrmOwners()
         {
-            _userManager.LoadSystemUsers();
+            _ownerManager.LoadSystemOwners();
         }
         private void LoadCrmArtefacts()
         {
             _artefactManagerFactory.GetManager(SelectedArtefactTypeName)
-                .QueryByUser(SelectedSourceUser);
+                .QueryByOwner(SelectedSourceOwner);
         }
 
         #endregion

--- a/NZ.XrmToolbox.PersonalArtefactManager/PersonalArtefactManagerControl.designer.cs
+++ b/NZ.XrmToolbox.PersonalArtefactManager/PersonalArtefactManagerControl.designer.cs
@@ -29,8 +29,8 @@
         private void InitializeComponent()
         {
             this.lvSourceUsers = new System.Windows.Forms.ListView();
-            this.colUserEmail = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
-            this.colUserName = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.colOwnerName = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
+            this.colOwnerLogicalName = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.lvCrmArtefacts = new System.Windows.Forms.ListView();
             this.colSelArtefacts = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
             this.colArtefactName = ((System.Windows.Forms.ColumnHeader)(new System.Windows.Forms.ColumnHeader()));
@@ -74,8 +74,8 @@
             this.lvSourceUsers.BorderStyle = System.Windows.Forms.BorderStyle.FixedSingle;
             this.lvSourceUsers.CheckBoxes = true;
             this.lvSourceUsers.Columns.AddRange(new System.Windows.Forms.ColumnHeader[] {
-            this.colUserEmail,
-            this.colUserName});
+            this.colOwnerName,
+            this.colOwnerLogicalName});
             this.lvSourceUsers.Enabled = false;
             this.lvSourceUsers.FullRowSelect = true;
             this.lvSourceUsers.GridLines = true;
@@ -91,15 +91,15 @@
             this.lvSourceUsers.View = System.Windows.Forms.View.Details;
             this.lvSourceUsers.SelectedIndexChanged += new System.EventHandler(this.lvSourceUsers_SelectedIndexChanged);
             // 
-            // colUserEmail
+            // colOwnerName
             // 
-            this.colUserEmail.Text = "Email";
-            this.colUserEmail.Width = 120;
+            this.colOwnerName.Text = "Name";
+            this.colOwnerName.Width = 120;
             // 
-            // colUserName
+            // colOwnerLogicalName
             // 
-            this.colUserName.Text = "Fullname";
-            this.colUserName.Width = 160;
+            this.colOwnerLogicalName.Text = "LogicalName";
+            this.colOwnerLogicalName.Width = 160;
             // 
             // lvCrmArtefacts
             // 
@@ -172,12 +172,12 @@
             // 
             // columnHeader5
             // 
-            this.columnHeader5.Text = "Email";
+            this.columnHeader5.Text = "Name";
             this.columnHeader5.Width = 120;
             // 
             // columnHeader6
             // 
-            this.columnHeader6.Text = "Fullname";
+            this.columnHeader6.Text = "LogicalName";
             this.columnHeader6.Width = 160;
             // 
             // tblLayoutListViews
@@ -217,7 +217,7 @@
             this.lblTargetUsersCaption.Name = "lblTargetUsersCaption";
             this.lblTargetUsersCaption.Size = new System.Drawing.Size(135, 17);
             this.lblTargetUsersCaption.TabIndex = 19;
-            this.lblTargetUsersCaption.Text = "3) Target User(s)";
+            this.lblTargetUsersCaption.Text = "3) Target User(s)/Team(s)";
             // 
             // lblCrmArtefactsCaption
             // 
@@ -273,7 +273,7 @@
             this.lblSourceUsersCaption.Name = "lblSourceUsersCaption";
             this.lblSourceUsersCaption.Size = new System.Drawing.Size(118, 17);
             this.lblSourceUsersCaption.TabIndex = 17;
-            this.lblSourceUsersCaption.Text = "1) Source User";
+            this.lblSourceUsersCaption.Text = "1) Source User/Team";
             // 
             // cbOperationSelector
             // 
@@ -448,8 +448,8 @@
         #endregion
         private System.Windows.Forms.ToolStrip toolStripMenu;
         
-        private System.Windows.Forms.ColumnHeader colUserEmail;
-        private System.Windows.Forms.ColumnHeader colUserName;
+        private System.Windows.Forms.ColumnHeader colOwnerName;
+        private System.Windows.Forms.ColumnHeader colOwnerLogicalName;
 		
         private System.Windows.Forms.ListView lvCrmArtefacts;
         private System.Windows.Forms.ColumnHeader colArtefactName;

--- a/NZ.XrmToolbox.PersonalArtefactManager/app.config
+++ b/NZ.XrmToolbox.PersonalArtefactManager/app.config
@@ -4,7 +4,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-2.29.0.1078" newVersion="2.29.0.1078" />
+        <bindingRedirect oldVersion="0.0.0.0-5.2.8.0" newVersion="5.2.8.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="Microsoft.IdentityModel.Clients.ActiveDirectory.WindowsForms" publicKeyToken="31bf3856ad364e35" culture="neutral" />
@@ -16,7 +16,7 @@
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Net.Http" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-4.1.0.0" newVersion="4.1.0.0" />
+        <bindingRedirect oldVersion="0.0.0.0-4.2.0.0" newVersion="4.2.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
@@ -49,6 +49,50 @@
       <dependentAssembly>
         <assemblyIdentity name="System.Runtime.Serialization.Primitives" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
         <bindingRedirect oldVersion="0.0.0.0-4.1.1.0" newVersion="4.1.1.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="Newtonsoft.Json" publicKeyToken="30ad4fe6b2a6aeed" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-13.0.0.0" newVersion="13.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Security.Cryptography.Pkcs" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="System.Security.Cryptography.Cng" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.0.0.0" newVersion="5.0.0.0" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NuGet.Common" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.10.0.7240" newVersion="5.10.0.7240" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NuGet.Frameworks" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.10.0.7240" newVersion="5.10.0.7240" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NuGet.Configuration" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.10.0.7240" newVersion="5.10.0.7240" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NuGet.Versioning" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.10.0.7240" newVersion="5.10.0.7240" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NuGet.Packaging" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.10.0.7240" newVersion="5.10.0.7240" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="NuGet.Protocol" publicKeyToken="31bf3856ad364e35" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-5.10.0.7240" newVersion="5.10.0.7240" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="McTools.Xrm.Connection" publicKeyToken="96037217801d9658" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2021.6.44" newVersion="1.2021.6.44" />
+      </dependentAssembly>
+      <dependentAssembly>
+        <assemblyIdentity name="McTools.Xrm.Connection.WinForms" publicKeyToken="f1559f79cf894e27" culture="neutral" />
+        <bindingRedirect oldVersion="0.0.0.0-1.2021.6.44" newVersion="1.2021.6.44" />
       </dependentAssembly>
     </assemblyBinding>
   </runtime>

--- a/NZ.XrmToolbox.PersonalArtefactManager/packages.config
+++ b/NZ.XrmToolbox.PersonalArtefactManager/packages.config
@@ -1,16 +1,27 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
-  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.0.7" targetFramework="net462" />
-  <package id="Microsoft.CrmSdk.Deployment" version="9.0.0.7" targetFramework="net462" />
-  <package id="Microsoft.CrmSdk.Workflow" version="9.0.0.7" targetFramework="net462" />
-  <package id="Microsoft.CrmSdk.XrmTooling.CoreAssembly" version="9.0.0.7" targetFramework="net462" />
+  <package id="DockPanelSuite" version="3.0.6" targetFramework="net462" />
+  <package id="DockPanelSuite.ThemeVS2015" version="3.0.6" targetFramework="net462" />
+  <package id="jacobslusser.ScintillaNET" version="3.6.3" targetFramework="net462" />
+  <package id="Microsoft.CrmSdk.CoreAssemblies" version="9.0.2.25" targetFramework="net462" />
+  <package id="Microsoft.CrmSdk.Deployment" version="9.0.2.25" targetFramework="net462" />
+  <package id="Microsoft.CrmSdk.Workflow" version="9.0.2.25" targetFramework="net462" />
+  <package id="Microsoft.CrmSdk.XrmTooling.CoreAssembly" version="9.1.0.79" targetFramework="net462" />
+  <package id="Microsoft.CrmSdk.XrmTooling.WpfControls" version="9.1.0.68" targetFramework="net462" />
   <package id="Microsoft.IdentityModel" version="6.1.7600.16394" targetFramework="net461" />
-  <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="2.29.0" targetFramework="net462" />
+  <package id="Microsoft.IdentityModel.Clients.ActiveDirectory" version="5.2.8" targetFramework="net462" />
+  <package id="Microsoft.Rest.ClientRuntime" version="2.3.20" targetFramework="net462" />
   <package id="Microsoft.Web.Xdt" version="2.1.1" targetFramework="net461" />
   <package id="Microsoft.Win32.Primitives" version="4.0.1" targetFramework="net462" />
-  <package id="MscrmTools.Xrm.Connection" version="1.2017.10.15" targetFramework="net462" />
-  <package id="Newtonsoft.Json" version="9.0.1" targetFramework="net462" />
+  <package id="MscrmTools.Xrm.Connection" version="1.2021.6.44" targetFramework="net462" />
+  <package id="Newtonsoft.Json" version="13.0.1" targetFramework="net462" />
+  <package id="NuGet.Common" version="5.10.0" targetFramework="net462" />
+  <package id="NuGet.Configuration" version="5.10.0" targetFramework="net462" />
   <package id="NuGet.Core" version="2.14.0" targetFramework="net462" />
+  <package id="NuGet.Frameworks" version="5.10.0" targetFramework="net462" />
+  <package id="NuGet.Packaging" version="5.10.0" targetFramework="net462" />
+  <package id="NuGet.Protocol" version="5.10.0" targetFramework="net462" />
+  <package id="NuGet.Versioning" version="5.10.0" targetFramework="net462" />
   <package id="System.Collections" version="4.0.11" targetFramework="net462" />
   <package id="System.Collections.Concurrent" version="4.0.12" targetFramework="net462" />
   <package id="System.Diagnostics.Debug" version="4.0.11" targetFramework="net462" />
@@ -18,7 +29,7 @@
   <package id="System.Globalization" version="4.0.11" targetFramework="net462" />
   <package id="System.IO" version="4.1.0" targetFramework="net462" />
   <package id="System.Linq" version="4.1.0" targetFramework="net462" />
-  <package id="System.Net.Http" version="4.1.0" targetFramework="net462" />
+  <package id="System.Net.Http" version="4.3.4" targetFramework="net462" />
   <package id="System.Net.Primitives" version="4.0.11" targetFramework="net462" />
   <package id="System.Reflection" version="4.1.0" targetFramework="net462" />
   <package id="System.Reflection.Extensions" version="4.0.1" targetFramework="net462" />
@@ -27,10 +38,12 @@
   <package id="System.Runtime.InteropServices" version="4.1.0" targetFramework="net462" />
   <package id="System.Runtime.Serialization.Json" version="4.0.2" targetFramework="net462" />
   <package id="System.Runtime.Serialization.Primitives" version="4.1.1" targetFramework="net462" />
-  <package id="System.Security.Cryptography.Algorithms" version="4.2.0" targetFramework="net462" />
-  <package id="System.Security.Cryptography.Encoding" version="4.0.0" targetFramework="net462" />
-  <package id="System.Security.Cryptography.Primitives" version="4.0.0" targetFramework="net462" />
-  <package id="System.Security.Cryptography.X509Certificates" version="4.1.0" targetFramework="net462" />
+  <package id="System.Security.Cryptography.Algorithms" version="4.3.1" targetFramework="net462" />
+  <package id="System.Security.Cryptography.Cng" version="5.0.0" targetFramework="net462" />
+  <package id="System.Security.Cryptography.Encoding" version="4.3.0" targetFramework="net462" />
+  <package id="System.Security.Cryptography.Pkcs" version="5.0.0" targetFramework="net462" />
+  <package id="System.Security.Cryptography.Primitives" version="4.3.0" targetFramework="net462" />
+  <package id="System.Security.Cryptography.X509Certificates" version="4.3.0" targetFramework="net462" />
   <package id="System.Text.Encoding" version="4.0.11" targetFramework="net462" />
   <package id="System.Text.Encoding.Extensions" version="4.0.11" targetFramework="net462" />
   <package id="System.Text.RegularExpressions" version="4.1.0" targetFramework="net462" />
@@ -38,5 +51,5 @@
   <package id="System.Threading.Tasks" version="4.0.11" targetFramework="net462" />
   <package id="System.Xml.ReaderWriter" version="4.0.11" targetFramework="net462" />
   <package id="System.Xml.XDocument" version="4.0.11" targetFramework="net462" />
-  <package id="XrmToolBoxPackage" version="1.2017.11.20" targetFramework="net462" />
+  <package id="XrmToolBoxPackage" version="1.2021.5.47" targetFramework="net462" />
 </packages>


### PR DESCRIPTION
I have changed things from being "User" oriented to being "Owner" oriented. This version now supports teams as well as systemusers. This has involved renaming the User and UserManager classes and files, as well as several other classes and files that used the User terminology. I tried to be thorough but not everything has been renamed. A future release could contain some minor variable name changes maybe.

When constructing instances of the Owner (formerly User) class, rather than using the Entity returned by querying the user, I convert it into an EntityReference and use that along with the primary field.

I have switched from using fullname, email in the tables to using the primary field (fullname for users, name for teams) and the logical name of the entity (systemuser, team) instead.

I have tested these changes with the use case I had in mind when I came across this tool and can verify that it worked as intended.